### PR TITLE
[Fix] Add taskId input for getcomments operation

### DIFF
--- a/nodes/Awork/actions/task/task.input.ts
+++ b/nodes/Awork/actions/task/task.input.ts
@@ -57,7 +57,8 @@ export const taskInputs: INodeProperties[] =
 						'changestatus',
 						'comments',
 						'settaskassignee',
-						'postaddtasktotasklist'
+						'postaddtasktotasklist',
+						'getcomments'
 					],
 				},
 			},


### PR DESCRIPTION
## Summary
- Added the `getcomments` operation to the Task ID input field's display options
- This fixes the Get Comments operation which was missing the required Task ID input

## Test plan
- [ ] Verify the Task ID field appears when selecting "Get Comments" operation for project tasks
- [ ] Test that fetching comments works correctly with the Task ID input

🤖 Generated with [Claude Code](https://claude.com/claude-code)