### PR TITLE
Add project-scoped project statuses operation

### DIFF
--- a/nodes/Awork/actions/project/project.input.ts
+++ b/nodes/Awork/actions/project/project.input.ts
@@ -13,6 +13,7 @@ export const projectInputs: INodeProperties[] =
 					],
 					operation: [
 						'get',
+						'getprojectstatusesofproject',
 						'gettaskstatuses',
 						'postprojectstatus',
 						'changeprojectstatus',

--- a/nodes/Awork/actions/project/project.resource.ts
+++ b/nodes/Awork/actions/project/project.resource.ts
@@ -50,11 +50,32 @@ export const projectResource: INodeProperties =
 		{
 			name: 'Get All Project Statuses',
 			value: 'getprojectstatuses',
-			action: 'Get projects statuses',
+			action: 'Get all project statuses',
 			routing: {
 				request: {
 					method: 'GET',
 					url: '=api/v1/projectstatuses',
+					qs: {
+						filterBy: '={{$parameter["filterBy"] || undefined}}',
+						orderBy: '={{$parameter["orderBy"] || undefined}}',
+					},
+				},
+				operations: {
+					pagination: aworkApiPagination,
+				},
+				send: {
+					paginate: true,
+				}
+			},
+		},
+		{
+			name: 'Get Project Statuses of Project',
+			value: 'getprojectstatusesofproject',
+			action: 'Get project statuses of project by id',
+			routing: {
+				request: {
+					method: 'GET',
+					url: '=api/v1/projects/{{$parameter["projectId"]}}/projectstatuses',
 					qs: {
 						filterBy: '={{$parameter["filterBy"] || undefined}}',
 						orderBy: '={{$parameter["orderBy"] || undefined}}',

--- a/nodes/Awork/common.properties.ts
+++ b/nodes/Awork/common.properties.ts
@@ -15,6 +15,7 @@ export const commonProperties: INodeProperties[] = [
 				],
 				operation: [
 					'getall',
+					'getprojectstatusesofproject',
 					'gettasksofproject',
 					'gettypesofwork',
 					'gettaskstatuses',
@@ -40,6 +41,7 @@ export const commonProperties: INodeProperties[] = [
 				],
 				operation: [
 					'getall',
+					'getprojectstatusesofproject',
 					'gettasksofproject',
 					'gettypesofwork',
 					'gettaskstatuses',
@@ -66,6 +68,7 @@ export const commonProperties: INodeProperties[] = [
 				],
 				operation: [
 					'getall',
+					'getprojectstatusesofproject',
 					'gettasksofproject',
 					'gettypesofwork',
 					'gettaskstatuses',


### PR DESCRIPTION
This PR adds support for GET /projects/{projectId}/projectstatuses as a new project operation (getprojectstatusesofproject). It preserves backward compatibility by keeping the existing getprojectstatuses value mapped to GET /projectstatuses. It also wires the new operation into shared Return All, Filter By, and Order By controls and requires Project ID for the scoped call.